### PR TITLE
Call ioctl() on cloned ethtool command

### DIFF
--- a/lib/rethtool.rb
+++ b/lib/rethtool.rb
@@ -32,12 +32,11 @@ class Rethtool
 		def ioctl(interface, ecmd)
 			sock = Socket.new(Socket::AF_INET, Socket::SOCK_DGRAM, 0)
 
-			ifreq = [interface, ecmd.data].pack("a16p")
+			rv = ecmd.clone
+			ifreq = [interface, ecmd.data].pack("a16P#{rv.data.length}")
 
 			sock.ioctl(SIOCETHTOOL, ifreq)
 
-			rv = ecmd.class.new
-			rv.data = ifreq.unpack("a16p")[1]
 			rv
 		end
 	end


### PR DESCRIPTION
The ethtool data is not necessarily null-terminated, so we have to pack it as a pointer to a fixed-length buffer. Since `SIOCETHTOOL` wants to write to this buffer, clone it first and pass the _new_ pointer.

Without this fix, Ruby 2.0.0p598 on CentOS 7 segfaults in the `unpack` call.
