### PR TITLE
Add DriverSettings class

### DIFF
--- a/lib/rethtool/driver_settings.rb
+++ b/lib/rethtool/driver_settings.rb
@@ -1,0 +1,36 @@
+require 'rethtool'
+require 'rethtool/ethtool_cmd'
+
+# Driver settings of a network interface.
+#
+# Create an instance of this class with the interface name as the only
+# parameter, then use the available instance methods to get the info you
+# seek:
+#
+#    if = Rethtool::DriverSettings.new("eth0")
+#    puts "Bus info is #{if.bus_info}"
+#
+class Rethtool::DriverSettings
+
+	# Create a new DriverSettings object.  Simply pass it the name of the
+	# interface you want to get the settings for.
+	def initialize(interface)
+		cmd_driver = Rethtool::EthtoolCmdDriver.new
+		cmd_driver.cmd = Rethtool::ETHTOOL_CMD_GDRVINFO
+		@driver_data = Rethtool.ioctl(interface, cmd_driver)
+	end
+
+	# Returns a string with the value of the interface driver (kernel module).
+	def driver
+		as_str(@driver_data.driver)
+	end
+
+	# Returns a string with the bus information of the interface.
+	def bus_info
+		as_str(@driver_data.bus_info)
+	end
+
+	def as_str(str)
+		str.pack('c*').delete("\000")
+	end
+end

--- a/lib/rethtool/interface_settings.rb
+++ b/lib/rethtool/interface_settings.rb
@@ -41,19 +41,17 @@ class Rethtool::InterfaceSettings
 		cmd.cmd = Rethtool::ETHTOOL_CMD_GSET
 		@data = Rethtool.ioctl(interface, cmd)
 
-		cmd_driver = Rethtool::EthtoolCmdDriver.new
-		cmd_driver.cmd = Rethtool::ETHTOOL_CMD_GDRVINFO
-		@driver_data = Rethtool.ioctl(interface, cmd_driver)
+		@driver_info = Rethtool::DriverSettings.new(interface)
 	end
 
         # Returns a string with the value of the interface driver (kernel module).
         def driver
-		as_str(@driver_data.driver)
+		@driver_info.driver
         end
 
         # Returns a string with the bus information of the interface.
         def bus_info
-		as_str(@driver_data.bus_info)
+		@driver_info.bus_info
         end
 	
 	# Return an array of the modes supported by the interface.  Returns an


### PR DESCRIPTION
It's not very convenient to do 2 ioctls in the same place,
because some drivers may not support some ioctls. For example
virtio driver can't return interface settings, but ioctl, which
returns driver settings works. So to have ability to get
driver info let's add second class, DriverSettings and use it
in InterfaceSettings (for compatibility).
